### PR TITLE
added drawSides() to init to fix initial loading

### DIFF
--- a/src/tertiary_text.c
+++ b/src/tertiary_text.c
@@ -342,6 +342,7 @@ int main(void) {
 //    };
     change_set(1, true);
     next();
+    drawSides();
     app_event_loop();
     deinit();
 }


### PR DESCRIPTION
added drawSides() in the init after next() to correctly display the text, otherwise it looks like this 
![tertiary](https://f.cloud.github.com/assets/1417043/1907836/be6df200-7cde-11e3-80e4-f041bc71d1b6.jpg) and subsequent button clicks still didn't load correctly. I realized that by long pressing the bottom button would bring the letters back correctly so I just used the method called from long bottom button press and fixes it so that it will load correctly
